### PR TITLE
refactor(bank-details):fix bank details management

### DIFF
--- a/app/Controllers/Features/FetchBankDetailFeature.js
+++ b/app/Controllers/Features/FetchBankDetailFeature.js
@@ -15,19 +15,11 @@ class FetchBankDetailFeature {
             const { user } = this.auth.current;
             const bankDetail = await BankDetail.findBy('user_id', user.id);
 
-            if(!bankDetail) {
-                return this.response.status(400).send({
-                    message: "Detail not found. Please, kindly update your bank detail",
-                    status: 'fail',
-                    status_code: 400,
-                });
-            }
-
             return this.response.status(200).send({
                 message: "Successfully fetched bank detail.",
                 status: 'Success',
                 status_code: 200,
-                result: bankDetail
+                result: bankDetail || {}
             });        
         } catch (fetchBankDetailError) {
             console.log("fetchBankDetailError", fetchBankDetailError)

--- a/app/Controllers/Features/ProcessWithdrawalFeature.js
+++ b/app/Controllers/Features/ProcessWithdrawalFeature.js
@@ -37,7 +37,7 @@ module.exports = class ProcessWithdrawal {
             const passwordVerified = await User.comparePassword(this.auth.current.user.id, password);
 
             if (!passwordVerified) {
-                return this.response.status(400).send({
+                return this.response.status(403).send({
                     message: "Incorrect password",
                     status: 'fail',
                     status_code: 403,
@@ -47,9 +47,9 @@ module.exports = class ProcessWithdrawal {
             const bankDetail = await BankDetail.findBy('user_id', this.auth.current.user.id);
 
             if (!bankDetail || !bankDetail.account_name || !bankDetail.account_number || !bankDetail.bank_id) {
-                return this.response.status(404).send({
+                return this.response.status(400).send({
                     status: 'Fail',
-                    status_code: 404,
+                    status_code: 400,
                     message: 'Please update your bank detail'
                 });
             }

--- a/app/Controllers/Features/RegisterUserFeature.js
+++ b/app/Controllers/Features/RegisterUserFeature.js
@@ -53,9 +53,9 @@ class RegisterUserFeature {
       await wallet.save();
 
       // bank detail
-      const bankDetail = new BankDetail();
-      bankDetail.user_id = user.id;
-      await bankDetail.save();
+      // const bankDetail = new BankDetail();
+      // bankDetail.user_id = user.id;
+      // await bankDetail.save();
 
       //profile
       const profile = new Profile();


### PR DESCRIPTION
- stop the creation of bank details entry for new users during user account creation

- send an empty object in the response if the user attempts to fetch his/her bank details and none is found